### PR TITLE
Add event settings endpoint

### DIFF
--- a/server/src/main/kotlin/eu/pretix/pretixscan/scanproxy/ProxyServer.kt
+++ b/server/src/main/kotlin/eu/pretix/pretixscan/scanproxy/ProxyServer.kt
@@ -63,6 +63,7 @@ object Server {
                             get("checkinlists/", CheckInListEndpoint)
                             get("orders/", EmptyResourceEndpoint)
                             get("badgeitems/", BadgeItemEndpoint)
+                            get("settings/", SettingsEndpoint)
                             get("subevents/:id/", SubEventEndpoint)
                         }
                     }

--- a/server/src/main/kotlin/eu/pretix/pretixscan/scanproxy/endpoints/ApiProxy.kt
+++ b/server/src/main/kotlin/eu/pretix/pretixscan/scanproxy/endpoints/ApiProxy.kt
@@ -93,6 +93,16 @@ object QuestionEndpoint : CachedResourceEndpoint() {
 }
 
 
+object SettingsEndpoint : Handler {
+    override fun handle(ctx: Context) {
+        val settings: Settings = Server.syncData.select(Settings::class.java)
+            .where(Settings.SLUG.eq(ctx.pathParam("event")))
+            .get().firstOrNull() ?: throw NotFoundResponse("Settings not found")
+        ctx.result(settings.json_data)
+    }
+}
+
+
 object DownloadEndpoint : Handler {
     override fun handle(ctx: Context) {
         val fname = ctx.pathParam("filename")


### PR DESCRIPTION
We (Fusion Festival) used the event settings for a custom feature in pretixscan-android. Since the covid certificate check also relies on event settings, I think it makes sense to add this upstream.