### PR TITLE
Names for downstream devices

### DIFF
--- a/server/src/main/kotlin/eu/pretix/pretixscan/scanproxy/ProxyServer.kt
+++ b/server/src/main/kotlin/eu/pretix/pretixscan/scanproxy/ProxyServer.kt
@@ -3,6 +3,7 @@ package eu.pretix.pretixscan.scanproxy
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.module.SimpleModule
 import eu.pretix.pretixscan.scanproxy.endpoints.*
+import eu.pretix.pretixscan.scanproxy.db.DownstreamDeviceEntity
 import eu.pretix.libpretixsync.serialization.JSONArraySerializer
 import eu.pretix.libpretixsync.serialization.JSONObjectSerializer
 import io.javalin.Javalin
@@ -30,7 +31,9 @@ object Server {
     fun main(args: Array<String>) {
         val app = Javalin.create { config ->
             config.requestLogger { ctx, executionTimeMs ->
-                LOG.info("[${ctx.ip()}] ${ctx.method()} ${ctx.path()} -> ${ctx.status()}")
+                var device: DownstreamDeviceEntity? = ctx.attribute("device")
+                val device_name = device?.name ?: ""
+                LOG.info("[${ctx.ip()}] '${device_name}' ${ctx.method()} ${ctx.path()} -> ${ctx.status()}")
             }
             config.prefer405over404 = true
             config.addStaticFiles("/public")

--- a/server/src/main/kotlin/eu/pretix/pretixscan/scanproxy/db/DownstreamDevice.kt
+++ b/server/src/main/kotlin/eu/pretix/pretixscan/scanproxy/db/DownstreamDevice.kt
@@ -13,4 +13,5 @@ interface DownstreamDevice : Persistable {
     var init_token: String?
     var api_token: String?
     var added_datetime: String?
+    var name: String?
 }

--- a/server/src/main/kotlin/eu/pretix/pretixscan/scanproxy/db/Migrations.kt
+++ b/server/src/main/kotlin/eu/pretix/pretixscan/scanproxy/db/Migrations.kt
@@ -11,7 +11,7 @@ import javax.sql.DataSource
 
 object Migrations {
     private val model = Models.DEFAULT
-    var CURRENT_VERSION = 5
+    var CURRENT_VERSION = 6
 
     @Throws(SQLException::class)
     private fun createVersionTable(c: Connection, version: Int) {
@@ -86,6 +86,14 @@ object Migrations {
                 "duplicate column name"
             )
             updateVersionTable(c, 5)
+        }
+        if (db_version < 6) {
+            execIgnore(
+                c,
+                "ALTER TABLE DownstreamDevice ADD name TEXT;",
+                "duplicate column name"
+            )
+            updateVersionTable(c, 6)
         }
 
     }

--- a/server/src/main/kotlin/eu/pretix/pretixscan/scanproxy/endpoints/Auth.kt
+++ b/server/src/main/kotlin/eu/pretix/pretixscan/scanproxy/endpoints/Auth.kt
@@ -32,6 +32,7 @@ object DeviceAuth : Handler {
                         where (DownstreamDeviceEntity.API_TOKEN.eq(auth[1]))
                 ).get()
         val device = result.firstOrNull() ?: throw UnauthorizedResponse("Unknown device token")
+        ctx.attribute("device", device)
     }
 }
 

--- a/server/src/main/kotlin/eu/pretix/pretixscan/scanproxy/endpoints/Rpc.kt
+++ b/server/src/main/kotlin/eu/pretix/pretixscan/scanproxy/endpoints/Rpc.kt
@@ -9,6 +9,7 @@ import eu.pretix.libpretixsync.db.*
 import eu.pretix.pretixscan.scanproxy.PretixScanConfig
 import eu.pretix.pretixscan.scanproxy.ProxyFileStorage
 import eu.pretix.pretixscan.scanproxy.Server
+import eu.pretix.pretixscan.scanproxy.db.DownstreamDeviceEntity
 import io.javalin.http.Context
 import io.javalin.http.Handler
 import io.javalin.http.NotFoundResponse
@@ -70,7 +71,8 @@ object CheckEndpoint : JsonBodyHandler<CheckInput>(CheckInput::class.java) {
         try {
             val type = TicketCheckProvider.CheckInType.valueOf((body.type ?: "entry").toUpperCase())
             val result = acp.check(body.ticketid, body.answers, body.ignore_unpaid, body.with_badge_data, type)
-            LOG.info("Scanned ticket '${body.ticketid}' result '${result.type}' time '${(System.currentTimeMillis() - startedAt) / 1000f}s' provider '${acp.javaClass.simpleName}'")
+            var device: DownstreamDeviceEntity = ctx.attribute("device")!!
+            LOG.info("Scanned ticket '${body.ticketid}' result '${result.type}' time '${(System.currentTimeMillis() - startedAt) / 1000f}s' device '${device.name}' provider '${acp.javaClass.simpleName}'")
             ctx.json(result)
             if (acp is OnlineCheckProvider) {
                 if (result.type == TicketCheckProvider.CheckResult.Type.ERROR) {

--- a/server/src/main/kotlin/eu/pretix/pretixscan/scanproxy/endpoints/SetupDownstream.kt
+++ b/server/src/main/kotlin/eu/pretix/pretixscan/scanproxy/endpoints/SetupDownstream.kt
@@ -15,9 +15,12 @@ data class SetupDownstreamInitResponse(
 )
 
 
-object SetupDownstreamInit : Handler {
+data class SetupDownstreamInitRequest(val name: String)
+
+
+object SetupDownstreamInit : JsonBodyHandler<SetupDownstreamInitRequest>(SetupDownstreamInitRequest::class.java) {
     private val charPool: List<Char> = ('a'..'z') + ('A'..'Z') + ('0'..'9')
-    override fun handle(ctx: Context) {
+    override fun handle(ctx: Context, body: SetupDownstreamInitRequest) {
         val configStore = PretixScanConfig(Server.dataDir, "", 0)
         if (!configStore.isConfigured) {
             throw ServiceUnavailableResponse("Not configured")
@@ -30,6 +33,7 @@ object SetupDownstreamInit : Handler {
         val baseurl = System.getProperty("pretixscan.baseurl", "http://URLNOTSET")
         val d = DownstreamDeviceEntity()
         d.uuid = UUID.randomUUID().toString()
+        d.name = body.name
         d.added_datetime = System.currentTimeMillis().toString()
         d.init_token = "proxy=" + (1..16)
             .map { i -> kotlin.random.Random.nextInt(0, SetupDownstreamInit.charPool.size) }
@@ -47,9 +51,9 @@ object SetupDownstreamInit : Handler {
 }
 
 
-object SetupDownstreamInitReady : Handler {
+object SetupDownstreamInitReady : JsonBodyHandler<SetupDownstreamInitRequest>(SetupDownstreamInitRequest::class.java) {
     private val charPool: List<Char> = ('a'..'z') + ('A'..'Z') + ('0'..'9')
-    override fun handle(ctx: Context) {
+    override fun handle(ctx: Context, body: SetupDownstreamInitRequest) {
         val configStore = PretixScanConfig(Server.dataDir, "", 0)
         if (!configStore.isConfigured) {
             throw ServiceUnavailableResponse("Not configured")
@@ -62,6 +66,7 @@ object SetupDownstreamInitReady : Handler {
         val baseurl = System.getProperty("pretixscan.baseurl", "http://URLNOTSET")
         val d = DownstreamDeviceEntity()
         d.uuid = UUID.randomUUID().toString()
+        d.name = body.name
         d.added_datetime = System.currentTimeMillis().toString()
         d.api_token = (1..64)
             .map { i -> kotlin.random.Random.nextInt(0, SetupDownstreamInitReady.charPool.size) }

--- a/server/src/main/kotlin/eu/pretix/pretixscan/scanproxy/endpoints/SetupUpstream.kt
+++ b/server/src/main/kotlin/eu/pretix/pretixscan/scanproxy/endpoints/SetupUpstream.kt
@@ -89,11 +89,12 @@ object ConfigState : Handler {
                 "configured" to configStore.isConfigured,
                 "organizer" to configStore.organizerSlug,
                 "upstreamUrl" to configStore.apiUrl,
-                "downstreamDevices" to (Server.proxyData select (DownstreamDeviceEntity::class)).get().map {
+                "downstreamDevices" to (Server.proxyData select (DownstreamDeviceEntity::class) orderBy (DownstreamDeviceEntity.NAME)).get().map {
                     return@map mapOf(
                         "uuid" to it.uuid,
                         "added_datetime" to if (it.added_datetime.isNullOrBlank()) null else Date(it.added_datetime!!.toLong()).toString(),
                         "init_token" to it.init_token,
+                        "name" to it.name,
                         "setup" to it.api_token.isNullOrBlank()
                     )
                 }.toList(),

--- a/server/src/main/resources/public/admin.js
+++ b/server/src/main/resources/public/admin.js
@@ -11,6 +11,7 @@ var app = new Vue({
     // app initial state
     data: {
         state: {},
+        newdevice_name: "",
         config_url: "https://pretix.eu",
         config_token: "",
         loading: 0,
@@ -78,20 +79,28 @@ var app = new Vue({
             }, err_handler);
         },
         newdevice: function () {
+            if (!this.newdevice_name) { return }
             this.loading++;
-            Vue.http.post("/proxyapi/v1/init").then(function (response) {
+            Vue.http.post("/proxyapi/v1/init", {
+                "name": this.newdevice_name
+            }).then(function (response) {
                 app.loading--;
                 app.init_data = response.body;
                 app.reload();
             }, err_handler);
+            this.newdevice_name = ""
         },
         newproxydevice: function () {
+            if (!this.newdevice_name) { return }
             this.loading++;
-            Vue.http.post("/proxyapi/v1/initready").then(function (response) {
+            Vue.http.post("/proxyapi/v1/initready", {
+                "name": this.newdevice_name
+            }).then(function (response) {
                 app.loading--;
                 app.init_data = response.body;
                 app.reload();
             }, err_handler);
+            this.newdevice_name = ""
         },
         configure: function () {
             this.loading++;

--- a/server/src/main/resources/public/index.html
+++ b/server/src/main/resources/public/index.html
@@ -171,8 +171,11 @@
                         </h3>
                     </div>
                     <div class="panel-body">
-                        <button class="btn btn-primary" type="button" @click="newdevice">Create a new pretixSCAN device</button>
-                        <button class="btn btn-default" type="button" @click="newproxydevice">Create a new Proxy-API device</button>
+                        <span class="form-inline">
+                            <input class="form-control" v-model="newdevice_name" placeholder="Device name" @keyup.enter="newdevice">
+                            <button class="btn btn-primary" type="button" v-bind:disabled="!newdevice_name" @click="newdevice">Create a new pretixSCAN device</button>
+                            <button class="btn btn-default" type="button" v-bind:disabled="!newdevice_name" @click="newproxydevice">Create a new Proxy-API device</button>
+                        </span>
                         <section class="init-token" v-if="init_data">
                             <qrcode v-if="initqr" :value="initqr" :options="{ width: 300 }"></qrcode>
                             <br>
@@ -182,13 +185,13 @@
                         <hr>
                         <table class="table">
                             <tr>
-                                <th>Device ID</th>
+                                <th>Name</th>
                                 <th>Initialization token</th>
                                 <th>Creation time</th>
                                 <th></th>
                             </tr>
                             <tr v-for="q in state.downstreamDevices">
-                                <td>{{q.uuid}}</td>
+                                <td>{{q.name}}</td>
                                 <td>{{q.init_token ? q.init_token : 'Already configured'}}</td>
                                 <td>{{q.added_datetime}}</td>
                                 <td>


### PR DESCRIPTION
Adds names to downstream devices similar to device registration in pretix. The names are visible in (api request and "Scanned ticket") log messages so scans and errors can be traced back to individual scanner devices. The names also replace the UUID in the admin UI.