### PR TITLE
Fix ANSWERS_REQUIRED checkin crash

### DIFF
--- a/server/src/main/kotlin/eu/pretix/pretixscan/scanproxy/endpoints/Rpc.kt
+++ b/server/src/main/kotlin/eu/pretix/pretixscan/scanproxy/endpoints/Rpc.kt
@@ -77,6 +77,13 @@ object CheckEndpoint : JsonBodyHandler<CheckInput>(CheckInput::class.java) {
                 body.with_badge_data,
                 type
             )
+            val requiredAnswers = result.requiredAnswers
+            if (requiredAnswers != null) {
+                val questions = requiredAnswers.map { it.question }
+                for (q in questions) {
+                    q.resolveDependency(questions)
+                }
+            }
             val device: DownstreamDeviceEntity = ctx.attribute("device")!!
             LOG.info("Scanned ticket '${body.ticketid}' result '${result.type}' time '${(System.currentTimeMillis() - startedAt) / 1000f}s' device '${device.name}' provider '${acp.javaClass.simpleName}'")
             ctx.json(result)


### PR DESCRIPTION
Serialization of `CheckResult` crashes if `requiredAnswers` is not empty, because `Question.resolveDependency` was not called:

```
[qtp1979766836-40] INFO eu.pretix.pretixscan.scanproxy.endpoints.MultiCheckEndpoint - Scanned ticket 'kb8xwqqpbyy8rm7c3jcjs3kfdhwmaqu7' result 'ANSWERS_REQUIRED' time '0.117s' device 'test' provider 'AsyncCheckProvider'
[qtp1979766836-40] WARN io.javalin.Javalin - Uncaught exception
com.fasterxml.jackson.databind.JsonMappingException: Question dependencies not resolved (through reference chain: eu.pretix.libpretixsync.check.TicketCheckProvider$CheckResult["requiredAnswers"]->java.util.ArrayList[0]->eu.pretix.libpretixsync.check.TicketCheckProvider$RequiredAnswer["question"]->eu.pretix.libpretixsync.db.Question["dependency"])
        at com.fasterxml.jackson.databind.JsonMappingException.wrapWithPath(JsonMappingException.java:392)
        at com.fasterxml.jackson.databind.JsonMappingException.wrapWithPath(JsonMappingException.java:351)
        at com.fasterxml.jackson.databind.ser.std.StdSerializer.wrapAndThrow(StdSerializer.java:316)
        at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:782)
        at com.fasterxml.jackson.databind.ser.BeanSerializer.serialize(BeanSerializer.java:178)
        at com.fasterxml.jackson.databind.ser.BeanPropertyWriter.serializeAsField(BeanPropertyWriter.java:728)
        at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:774)
        at com.fasterxml.jackson.databind.ser.BeanSerializer.serialize(BeanSerializer.java:178)
        at com.fasterxml.jackson.databind.ser.impl.IndexedListSerializer.serializeContentsUsing(IndexedListSerializer.java:142)
        at com.fasterxml.jackson.databind.ser.impl.IndexedListSerializer.serializeContents(IndexedListSerializer.java:88)
        at com.fasterxml.jackson.databind.ser.impl.IndexedListSerializer.serialize(IndexedListSerializer.java:79)
        at com.fasterxml.jackson.databind.ser.impl.IndexedListSerializer.serialize(IndexedListSerializer.java:18)
        at com.fasterxml.jackson.databind.ser.BeanPropertyWriter.serializeAsField(BeanPropertyWriter.java:728)
        at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:774)
        at com.fasterxml.jackson.databind.ser.BeanSerializer.serialize(BeanSerializer.java:178)
        at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider._serialize(DefaultSerializerProvider.java:480)
        at com.fasterxml.jackson.databind.ser.DefaultSerializerProvider.serializeValue(DefaultSerializerProvider.java:319)
        at com.fasterxml.jackson.databind.ObjectMapper._writeValueAndClose(ObjectMapper.java:4569)
        at com.fasterxml.jackson.databind.ObjectMapper.writeValueAsString(ObjectMapper.java:3822)
        at io.javalin.plugin.json.JavalinJackson.toJson(JavalinJackson.kt:39)
        at io.javalin.plugin.json.JavalinJson$toJsonMapper$1.map(JavalinJson.kt:28)
        at io.javalin.plugin.json.JavalinJson.toJson(JavalinJson.kt:32)
        at io.javalin.http.Context.json(Context.kt:468)
        at eu.pretix.pretixscan.scanproxy.endpoints.MultiCheckEndpoint.handle(Rpc.kt:127)
        at eu.pretix.pretixscan.scanproxy.endpoints.MultiCheckEndpoint.handle(Rpc.kt:107)
        at eu.pretix.pretixscan.scanproxy.endpoints.JsonBodyHandler.handle(Utils.kt:24)
        at io.javalin.core.security.SecurityUtil.noopAccessManager(SecurityUtil.kt:23)
        at io.javalin.http.JavalinServlet$addHandler$protectedHandler$1.handle(JavalinServlet.kt:128)
        at io.javalin.http.JavalinServlet$service$2$1.invoke(JavalinServlet.kt:45)
        at io.javalin.http.JavalinServlet$service$2$1.invoke(JavalinServlet.kt:24)
        at io.javalin.http.JavalinServlet$service$1.invoke(JavalinServlet.kt:136)
        at io.javalin.http.JavalinServlet$service$2.invoke(JavalinServlet.kt:40)
        at io.javalin.http.JavalinServlet.service(JavalinServlet.kt:81)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
        at io.javalin.websocket.JavalinWsServlet.service(JavalinWsServlet.kt:51)
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:790)
        at org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:799)
        at org.eclipse.jetty.servlet.ServletHandler.doHandle(ServletHandler.java:550)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:233)
        at org.eclipse.jetty.server.session.SessionHandler.doHandle(SessionHandler.java:1624)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextHandle(ScopedHandler.java:233)
        at io.javalin.core.JavalinServer$start$wsAndHttpHandler$1.doHandle(JavalinServer.kt:49)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:188)
        at org.eclipse.jetty.servlet.ServletHandler.doScope(ServletHandler.java:501)
        at org.eclipse.jetty.server.session.SessionHandler.doScope(SessionHandler.java:1594)
        at org.eclipse.jetty.server.handler.ScopedHandler.nextScope(ScopedHandler.java:186)
        at org.eclipse.jetty.server.handler.ContextHandler.doScope(ContextHandler.java:1349)
        at org.eclipse.jetty.server.handler.ScopedHandler.handle(ScopedHandler.java:141)
        at org.eclipse.jetty.server.handler.StatisticsHandler.handle(StatisticsHandler.java:179)
        at org.eclipse.jetty.server.handler.HandlerWrapper.handle(HandlerWrapper.java:127)
        at org.eclipse.jetty.server.Server.handle(Server.java:516)
        at org.eclipse.jetty.server.HttpChannel.lambda$handle$1(HttpChannel.java:388)
        at org.eclipse.jetty.server.HttpChannel.dispatch(HttpChannel.java:633)
        at org.eclipse.jetty.server.HttpChannel.handle(HttpChannel.java:380)
        at org.eclipse.jetty.server.HttpConnection.onFillable(HttpConnection.java:277)
        at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:311)
        at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:105)
        at org.eclipse.jetty.io.ChannelEndPoint$1.run(ChannelEndPoint.java:104)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:338)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:315)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:173)
        at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:131)
        at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run(ReservedThreadExecutor.java:386)
        at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:883)
        at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:1034)
        at java.base/java.lang.Thread.run(Thread.java:1623)
Caused by: java.lang.IllegalStateException: Question dependencies not resolved
        at eu.pretix.libpretixsync.db.AbstractQuestion.getDependency(AbstractQuestion.java:133)
        at eu.pretix.libpretixsync.db.AbstractQuestion.getDependency(AbstractQuestion.java:133)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
        at java.base/java.lang.reflect.Method.invoke(Method.java:578)
        at com.fasterxml.jackson.databind.ser.BeanPropertyWriter.serializeAsField(BeanPropertyWriter.java:689)
        at com.fasterxml.jackson.databind.ser.std.BeanSerializerBase.serializeFields(BeanSerializerBase.java:774)
        ... 62 more
[qtp1979766836-40] INFO eu.pretix.pretixscan.scanproxy.Server - [192.168.178.26] 'test' POST /proxyapi/v1/rpc/check/ -> 500
```

The added code is essentially copied from pretixscan-android (showQuestionsDialog in MainActivity.kt).