### PR TITLE
Fix content type of settings endpoint

### DIFF
--- a/server/src/main/kotlin/eu/pretix/pretixscan/scanproxy/endpoints/ApiProxy.kt
+++ b/server/src/main/kotlin/eu/pretix/pretixscan/scanproxy/endpoints/ApiProxy.kt
@@ -98,7 +98,7 @@ object SettingsEndpoint : Handler {
         val settings: Settings = Server.syncData.select(Settings::class.java)
             .where(Settings.SLUG.eq(ctx.pathParam("event")))
             .get().firstOrNull() ?: throw NotFoundResponse("Settings not found")
-        ctx.result(settings.json_data)
+        ctx.json(settings.getJSON())
     }
 }
 


### PR DESCRIPTION
I did not notice when I added the settings endpoint in #7, but its responses have the wrong content type (`text/plain` instead of `application/json`). This causes charset problems in the app if the settings contain non-ASCII characters.